### PR TITLE
Removed redundant link from SEE ALSO section.

### DIFF
--- a/lib/Bot/IRC.pm
+++ b/lib/Bot/IRC.pm
@@ -1227,7 +1227,6 @@ You can look for additional information at:
 
 =for :list
 * L<GitHub|https://github.com/gryphonshafer/Bot-IRC>
-* L<CPAN|http://search.cpan.org/dist/Bot-IRC>
 * L<MetaCPAN|https://metacpan.org/pod/Bot::IRC>
 * L<AnnoCPAN|http://annocpan.org/dist/Bot-IRC>
 * L<Travis CI|https://travis-ci.org/gryphonshafer/Bot-IRC>


### PR DESCRIPTION
Hi @gryphonshafer 

Please review the PR.
The link CPAN search site is not longer active.

Many Thanks.
Best Regards,
Mohammad S Anwar