### PR TITLE
Fix connecting when no initial message is sent by the server.

### DIFF
--- a/lib/Bot/IRC.pm
+++ b/lib/Bot/IRC.pm
@@ -137,6 +137,9 @@ sub _parent {
     my @lines;
 
     try {
+        $self->say("USER $self->{nick} 0 * :$self->{connect}{name}");
+        $self->say("NICK $self->{nick}");
+
         while ( my $line = $self->{socket}->getline ) {
             $line =~ s/\003\d{2}(?:,\d{2})?//g; # remove IRC color codes
             $line =~ tr/\000-\037//d;           # remove all control characters
@@ -154,11 +157,6 @@ sub _parent {
                 elsif ( $line =~ /^ERROR\s/ ) {
                     warn "$line\n";
                     $device->daemon->do_stop;
-                }
-                elsif ( not $session->{user} ) {
-                    $self->say("USER $self->{nick} 0 * :$self->{connect}{name}");
-                    $self->say("NICK $self->{nick}");
-                    $session->{user} = 1;
                 }
                 elsif ( $line =~ /^:\S+\s433\s/ ) {
                     $self->nick( $self->{nick} . '_' );


### PR DESCRIPTION
This resolves #3. Basically, if a server does not send any initial messages (the 'getting your username/hostname'/etc lines), then the bot will fail to connect. `NICK` and `USER` should always be sent on connection, so this change makes the bot do those before starting the main getline loop.