### PR TITLE
run: use IP instead of INET module for supporting IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ version 1.25
             name   => 'Yet Another IRC Bot',
             join   => [ '#test', '#perl' ],
             ssl    => 0,
+            ipv6   => 0,
         },
         plugins => [
             ':core',
@@ -129,6 +130,7 @@ set or added to through other methods off the instantiated object.
             name   => 'Yet Another IRC Bot',
             join   => [ '#test', '#perl' ],
             ssl    => 0,
+            ipv6   => 0,
         },
         plugins => [],
         vars    => {},
@@ -137,7 +139,8 @@ set or added to through other methods off the instantiated object.
 `spawn` will default to 2. Under `connect`, `port` will default to 6667.
 `join` can be either a string or an arrayref of strings representing channels
 to join after connnecting. `ssl` is a true/false setting for whether to
-connect to the server over SSL.
+connect to the server over SSL. `ipv6` is also true/false setting for whether
+to forcibly connect to the server over IPv6.
 
 Read more about plugins below for more information about `plugins` and `vars`.
 Consult [Daemon::Device](https://metacpan.org/pod/Daemon::Device) and [Daemon::Control](https://metacpan.org/pod/Daemon::Control) for more details about `spawn`

--- a/lib/Bot/IRC.pm
+++ b/lib/Bot/IRC.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use Carp 'croak';
 use Daemon::Device;
-use IO::Socket;
+use IO::Socket::IP -register;
 use IO::Socket::SSL;
 use Time::Crontab;
 use Date::Format 'time2str';
@@ -59,10 +59,11 @@ sub run {
     my $self     = shift;
     my $commands = \@_;
 
-    $self->{socket} = ( ( $self->{connect}{ssl} ) ? 'IO::Socket::SSL' : 'IO::Socket::INET' )->new(
+    $self->{socket} = ( ( $self->{connect}{ssl} ) ? 'IO::Socket::SSL' : 'IO::Socket::IP' )->new(
         PeerAddr        => $self->{connect}{server},
         PeerPort        => $self->{connect}{port},
         Proto           => 'tcp',
+        Family          => ( $self->{connect}{ipv6} ? AF_INET6 : AF_INET ),
         Type            => SOCK_STREAM,
         SSL_verify_mode => SSL_VERIFY_NONE,
     ) or die $!;
@@ -706,6 +707,7 @@ __END__
             name   => 'Yet Another IRC Bot',
             join   => [ '#test', '#perl' ],
             ssl    => 0,
+            ipv6   => 0,
         },
         plugins => [
             ':core',
@@ -797,6 +799,7 @@ set or added to through other methods off the instantiated object.
             name   => 'Yet Another IRC Bot',
             join   => [ '#test', '#perl' ],
             ssl    => 0,
+            ipv6   => 0,
         },
         plugins => [],
         vars    => {},
@@ -805,7 +808,8 @@ set or added to through other methods off the instantiated object.
 C<spawn> will default to 2. Under C<connect>, C<port> will default to 6667.
 C<join> can be either a string or an arrayref of strings representing channels
 to join after connnecting. C<ssl> is a true/false setting for whether to
-connect to the server over SSL.
+connect to the server over SSL. C<ipv6> is also true/false setting for whether
+to forcibly connect to the server over IPv6.
 
 Read more about plugins below for more information about C<plugins> and C<vars>.
 Consult L<Daemon::Device> and L<Daemon::Control> for more details about C<spawn>

--- a/t/bot-irc-api.t
+++ b/t/bot-irc-api.t
@@ -30,6 +30,7 @@ my $settings = {
         name   => 'Yet Another IRC Bot',
         join   => [ '#test', '#perl' ],
         ssl    => 0,
+        ipv6   => 0,
     },
 };
 

--- a/t/bot-irc-run.t
+++ b/t/bot-irc-run.t
@@ -5,7 +5,7 @@ use Test::Most;
 use Test::MockModule;
 use Test::Output;
 
-my $socket = Test::MockModule->new('IO::Socket::INET');
+my $socket = Test::MockModule->new('IO::Socket::IP');
 $socket->mock( new => sub {
     return bless( {}, shift );
 } );
@@ -40,6 +40,7 @@ my $settings = {
         name   => 'Yet Another IRC Bot',
         join   => [ '#test', '#perl' ],
         ssl    => 0,
+        ipv6   => 0,
     },
 };
 


### PR DESCRIPTION
Some servers have the ipaddr ban list for certain IPv4 addresses, which,
unfortunately, sometimes (when the user uses dynamic addr) are blocked but the
user has nothing to do with that and, therefore, the bot is also blocked.

This patch adds IO::Socket::IP module for handling both IPv4 and v6 upon user
configuration, in case he wants to force it.

Resolves issue #6 .