### PR TITLE
Better emotes using CTCP ACTION

### DIFF
--- a/lib/Bot/IRC.pm
+++ b/lib/Bot/IRC.pm
@@ -587,7 +587,12 @@ sub reply_to {
 
 sub msg {
     my ( $self, $target, $message ) = @_;
-    $self->say("PRIVMSG $target :$message");
+    if ($message =~ /^\/me\s+/) {
+       $message =~ s/^\/me\s+//;
+       $self->say("PRIVMSG $target :\001ACTION $message\001");
+    } else {
+       $self->say("PRIVMSG $target :$message");
+    }
     return $self;
 }
 


### PR DESCRIPTION
For most clients, /me is handled as a CTCP action, so
make this IRC client do that, too.  Then other clients will
see it properly.